### PR TITLE
Fix bug with empty content update handling

### DIFF
--- a/appconfig_helper/appconfig_helper.py
+++ b/appconfig_helper/appconfig_helper.py
@@ -152,6 +152,7 @@ class AppConfigHelper:
 
         content = response["Configuration"].read()  # type: bytes
         if content == b"":
+            self._last_update_time = time.time()
             return False
 
         if response["ContentType"] == "application/x-yaml":


### PR DESCRIPTION
Not updating the last update time when receiving an empty config from
the service can result in the library calling the service again too
soon, which raises an exception.

Reported-by: @jrobbins-LiveData

Fixes #2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
