### PR TITLE
Add recovery for ClientError in update_config function

### DIFF
--- a/appconfig_helper/appconfig_helper.py
+++ b/appconfig_helper/appconfig_helper.py
@@ -8,6 +8,7 @@ import time
 from typing import Any, Dict, Optional, Union
 
 import boto3
+import botocore
 
 try:
     import yaml
@@ -144,9 +145,16 @@ class AppConfigHelper:
         if self._next_config_token is None:
             self.start_session()
 
-        response = self._client.get_latest_configuration(
-            ConfigurationToken=self._next_config_token
-        )
+        try:
+            response = self._client.get_latest_configuration(
+                ConfigurationToken=self._next_config_token
+            )
+        except botocore.exceptions.ClientError:
+                self.start_session()
+                response = self._client.get_latest_configuration(
+                    ConfigurationToken=self._next_config_token
+                )
+
         self._next_config_token = response["NextPollConfigurationToken"]
         self._poll_interval = int(response["NextPollIntervalInSeconds"])
 

--- a/appconfig_helper/appconfig_helper.py
+++ b/appconfig_helper/appconfig_helper.py
@@ -150,10 +150,10 @@ class AppConfigHelper:
                 ConfigurationToken=self._next_config_token
             )
         except botocore.exceptions.ClientError:
-                self.start_session()
-                response = self._client.get_latest_configuration(
-                    ConfigurationToken=self._next_config_token
-                )
+            self.start_session()
+            response = self._client.get_latest_configuration(
+                ConfigurationToken=self._next_config_token
+            )
 
         self._next_config_token = response["NextPollConfigurationToken"]
         self._poll_interval = int(response["NextPollIntervalInSeconds"])


### PR DESCRIPTION
*Issue #, if available:* #5

*Description of changes:*

If get_latest_configuration raises a ClientError, it'll be caught and a
new session started before get_latest_configuration is called again.

Second call to get_latest_configuration is not caught so any second
error will be raised by update_config as it previously was.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

PS: Sorry for delay in submitting PR, I have been swamped recently.
